### PR TITLE
ng-class for no file chosen text

### DIFF
--- a/src/viewer/templates/material/mw-form-question.html
+++ b/src/viewer/templates/material/mw-form-question.html
@@ -166,7 +166,7 @@
         </div>
         <div ng-switch-when="file" class="form-inline">
             <md-input-container>
-                <input class="form-control" type="file" accept=".png, .tif, .jpg, .jpeg, .pdf" fileread="ctrl.questionResponse.answer"  ng-readonly="ctrl.readOnly" ng-required="ctrl.question.required" placeholder="&nbsp &nbsp &nbsp &nbsp &nbsp &nbsp &nbsp&nbsp &nbsp &nbsp &nbsp &nbsp &nbsp Max file size 1MB">
+                <input class="form-control" ng-class="ctrl.questionResponse.answer == 'undefined' ? 'fileupload-text' : 'fileupload-text-black'" ng-model="ctrl.questionResponse.fileName" type="file" accept=".png, .tif, .jpg, .jpeg, .pdf" fileread="ctrl.questionResponse.answer"  ng-readonly="ctrl.readOnly" ng-required="ctrl.question.required" placeholder="&nbsp &nbsp &nbsp &nbsp &nbsp &nbsp &nbsp&nbsp &nbsp &nbsp &nbsp &nbsp &nbsp Max file size 1MB">
             </md-input-container>
             <span ng-if="ctrl.largeFileFlag" style="color:red;">
                 *File size is large


### PR DESCRIPTION
**What does this PR do?**
 added the ng class for "no file chosen" text

**Where should the reviewer start?**
src/viewer/templates/material/mw-form-question.html

How should this be manually tested?
 "no file chosen" text will not come if file is already uploaded

Any background context you want to provide?

What is/are the relevant trello card(s)?

Screenshots (if appropriate)
Questions:
Are there changes to database structures?
Are there dependencies to be added?